### PR TITLE
Widen psr/simple-cache constraint to ^1.0 || ^2.0 || ^3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   ],
   "require": {
     "php": ">=8.1",
-    "psr/simple-cache": "^3.0",
+    "psr/simple-cache": "^1.0 || ^2.0 || ^3.0",
     "symfony/string": "^6.4 || ^7.0 || ^8.0"
   },
   "require-dev": {


### PR DESCRIPTION
## Summary

This widens the `psr/simple-cache` constraint in `composer.json` from `^3.0` to `^1.0 || ^2.0 || ^3.0`. One-line change, no source-code edits.

## Why this is safe

`CacheInterface` is referenced in `src/TailwindMerge.php` only:

- `private readonly ?CacheInterface $cache = null` as an optional constructor parameter
- `if (!$this->cache instanceof CacheInterface) { return $this->merger->merge($classList); }` gating the cache-or-compute path

Every call site is gated behind an `instanceof CacheInterface` check. The library invokes only methods that exist identically across PSR-16 v1, v2, and v3 (`get($key)`, `set($key, $value)`). No v3-specific method signature or behavior is exercised, so widening the constraint changes nothing at runtime.

## Why it matters

PSR-16 v1 is still pinned by a sizable slice of the PHP ecosystem. Two examples I hit while integrating this library into a Craft CMS plugin:

- `ibericode/vat ^1.2.2` requires `psr/simple-cache ^1.0`, and `craftcms/commerce` 5.x transitively pins `ibericode/vat ^1.2.2`. Any project that installs Commerce can't currently install this library.
- Several `illuminate/contracts` 10.x consumers ship with `psr/simple-cache ^1.0|^2.0|^3.0` but downstream packages of theirs are still on `^1.0`-only.

The current `^3.0` constraint is locking the library out of those environments for no functional reason. Once installed, both v1 and v3 callers can share the same loaded interface as long as user-supplied cache implementations match whichever version was resolved.

## Test plan

- CI continues to resolve to `psr/simple-cache ^3.0` by default (Composer prefers the highest matching constraint), so no behavior change for existing test runs.
- Local sanity check: `composer require --dev psr/simple-cache:^1.0` after the widen. Library loads, existing tests pass with the no-cache code path.